### PR TITLE
Atualiza valores dos formularios a partir do objeto values

### DIFF
--- a/src/connectToState.js
+++ b/src/connectToState.js
@@ -54,6 +54,7 @@ export default function connectToState(CreditCardInput) {
 
     componentDidMount = () => setTimeout(() => { // Hacks because componentDidMount happens before component is rendered
       this.props.autoFocus && this.focus("number");
+      this.setValues(this.props.values);
     });
 
     setValues = values => {


### PR DESCRIPTION
Let's Say we have some credit card in our database and we want to edit it using this card form. I was struggling with this issue and found out that when I passed the `values`  prop to the `CreditCardInput` nothing would happen. 

Also, I tried to use additionalInputsProps as suggested in the readme:

     <CreditCardInput 
        ...other props
        additionalInputsProps= name: {
        defaultValue: 'Tony Stark',
     } />


But still the values I passed were reflected in the form or cardView. So, I noticed that in the `connectToState.js` the values were only injected or passed to the `CreditCardInput` component if the user manually changed the TextInputs values. So What I did to fix this was setting the values in the `componentDidMount`:

    // src/connectToState.js
    componentDidMount = () => setTimeout(() => {   
       this.props.autoFocus && this.focus("number");
       this.setValues(this.props.values); // Added this line to initially set default values to form
    });


So now, using the component like this works fine:


    <CreditCardInput
          ...
          values={{
           name: "Tony Stark",
           number: "4111***111",
           expiry: "12/22",
           cvc: "122"
         }}


I'd like to continue using and contributing with this repo. Also, I need this change/feature in order to finish a project I'm working on...So it'd be great if you upgrade the rpm version so I don't have to use it locally. 

Nice work, keep it up! 