### PR TITLE
IInputPlaceholders typo fix, and missing fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,9 +40,11 @@ declare module 'react-native-input-credit-card' {
   }
 
   export interface IInputPlaceholders {
+    name: string
     number: string
-    expirty: string
+    expiry: string
     cvc: string
+    postalCode: string
   }
 
   export interface ILiteCreditCardInputs {


### PR DESCRIPTION
Ran into this in my current project.

This is a typo in `expiry`, and the `name` and `postalCode` fields are missing. They are necessary for full localization of the component.