### PR TITLE
Add an option to show or hide last 4 digits

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,7 @@ _onChange => form => console.log(form);
 |validColor | PropTypes.string | Color that will be applied for valid text input. Defaults to: "{inputStyle.color}" |
 |invalidColor | PropTypes.string | Color that will be applied for invalid text input. Defaults to: "red" |
 |placeholderColor | PropTypes.string | Color that will be applied for text input placeholder. Defaults to: "gray" |
+|showLast4 | PropTypes.bool | Shows last 4 card number digits when editing expiry or CVC. Default to `true` |
 | additionalInputsProps | PropTypes.objectOf(TextInput.propTypes) | An object with Each key of the object corresponding to the name of the field. Allows you to change all props documented in [RN TextInput](https://facebook.github.io/react-native/docs/textinput.html).
 
 #### NOTES

--- a/src/LiteCreditCardInput.js
+++ b/src/LiteCreditCardInput.js
@@ -58,6 +58,9 @@ const s = StyleSheet.create({
     width: 60,
     marginLeft: 20,
   },
+  last4InputHiddenView: {
+    width: 20,
+  },
   input: {
     height: 40,
     color: "black",
@@ -76,6 +79,7 @@ export default class LiteCreditCardInput extends Component {
     validColor: PropTypes.string,
     invalidColor: PropTypes.string,
     placeholderColor: PropTypes.string,
+    showLast4: PropTypes.bool,
 
     additionalInputsProps: PropTypes.objectOf(PropTypes.shape(TextInput.propTypes)),
   };
@@ -89,6 +93,7 @@ export default class LiteCreditCardInput extends Component {
     validColor: "",
     invalidColor: "red",
     placeholderColor: "gray",
+    showLast4: true,
     additionalInputsProps: {},
   };
 
@@ -150,6 +155,7 @@ export default class LiteCreditCardInput extends Component {
       focused,
       values: { number },
       inputStyle,
+      showLast4,
       status: {
         number: numberStatus
       }
@@ -176,19 +182,23 @@ export default class LiteCreditCardInput extends Component {
           s.rightPart,
           showRightPart ? s.expanded : s.hidden,
         ]}>
-          <TouchableOpacity
-            onPress={this._focusNumber}
-            style={s.last4}
-          >
-            <View pointerEvents={"none"}>
-              <CCInput field="last4"
-                keyboardType="numeric"
-                value={numberStatus === "valid" ? number.substr(number.length - 4, 4) : ""}
-                inputStyle={[s.input, inputStyle]}
-                containerStyle={[s.last4Input]}
-              />
-            </View>
-          </TouchableOpacity>
+          {showLast4 ? (
+            <TouchableOpacity onPress={this._focusNumber} style={s.last4}>
+              <View pointerEvents={"none"}>
+                <CCInput
+                  field="last4"
+                  keyboardType="numeric"
+                  value={
+                    numberStatus === "valid"
+                      ? number.substr(number.length - 4, 4)
+                      : ""
+                  }
+                  inputStyle={[s.input, inputStyle]}
+                  containerStyle={[s.last4Input]}
+                />
+              </View>
+            </TouchableOpacity>
+          ) : (<View style={s.last4InputHiddenView} />)}
           <CCInput
             {...this._inputProps("expiry")}
             keyboardType="numeric"


### PR DESCRIPTION
When using the Lite component on very small screen, the last digits can overlap the expiry field. I've added an option to show or hide those 4 last digits.

Before
![Simulator Screen Shot - iPhone SE - 2020-03-25 at 15 40 28](https://user-images.githubusercontent.com/485107/77548886-6faa8600-6eaf-11ea-82a1-3f0ad5678d2a.png)
After
![Simulator Screen Shot - iPhone SE - 2020-03-25 at 15 42 11](https://user-images.githubusercontent.com/485107/77548902-73d6a380-6eaf-11ea-813a-eacc77626054.png)